### PR TITLE
fixing rvm default ruby selection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN \curl -sSL https://get.rvm.io | bash -s stable
 RUN /usr/local/rvm/bin/rvm install ruby-head
 RUN /usr/local/rvm/bin/rvm install 1.8.7
 RUN /usr/local/rvm/bin/rvm install 1.9.2
-RUN /usr/local/rvm/bin/rvm install 1.9.3 && /root/.rvm/bin/rvm alias create default 1.9.3
+RUN /usr/local/rvm/bin/rvm install 1.9.3 && /usr/local/rvm/bin/rvm alias create default 1.9.3
 RUN /usr/local/rvm/bin/rvm install 2.0.0
 RUN /usr/local/rvm/bin/rvm install 2.1.1
 RUN /usr/local/rvm/bin/rvm install jruby


### PR DESCRIPTION
- https://github.com/Shippable/pm/issues/2520
- fixing rvm default ruby selection
- docker build completes when tested locally